### PR TITLE
#33 Renew spotify token

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,5 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
 
 import Navbar from 'components/Navbar';
 import Authroute from 'tools/Authroute';
@@ -20,7 +19,6 @@ const App = () => {
       <Router>
         <div>
           <Navbar />
-
           <Switch>
             <Authroute exact path="/new-playlist" component={NewPlaylist} />
             <Route exact path="/register" component={Register} />

--- a/src/components/PlaylistTable/index.jsx
+++ b/src/components/PlaylistTable/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import APIManager from 'services/APIManager';
-
+import shortID from 'shortid';
 import { makeStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import Table from '@material-ui/core/Table';
@@ -109,7 +109,7 @@ const PlaylistTable = ({ spotifyDetails }: PlaylistTable) => {
             <TableRow>
               {columns.map((column) => (
                 <TableCell
-                  key={column.id}
+                  key={shortID.generate()}
                   align={column.align}
                   style={{ minWidth: column.minWidth }}
                 >
@@ -134,12 +134,15 @@ const PlaylistTable = ({ spotifyDetails }: PlaylistTable) => {
                       hover
                       role="checkbox"
                       tabIndex={-1}
-                      key={row.code}
+                      key={shortID.generate()}
                     >
                       {columns.map((column) => {
                         const value = row[column.id];
                         return (
-                          <TableCell key={column.id} align={column.align}>
+                          <TableCell
+                            key={shortID.generate()}
+                            align={column.align}
+                          >
                             {column.format && typeof value === 'number'
                               ? column.format(value)
                               : value}

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,1 +1,2 @@
 export const cookieName = 'mixUpUserCookie';
+export const cookieNameForSpotifyAuth = 'mixUpSpotifyAuthCookie';

--- a/src/services/APIManager/index.jsx
+++ b/src/services/APIManager/index.jsx
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import Cookies from 'js-cookie';
+import { cookieName } from '../../constants';
 
 const API = axios.create({
   baseURL: 'https://mixup-the-app.herokuapp.com',
@@ -11,7 +12,7 @@ API.interceptors.request.use(
     headers: {
       ...headers,
       'Content-Type': 'application/json',
-      Authorization: headers.Authorization || Cookies.get('token'),
+      Authorization: Cookies.get(cookieName),
     },
   }),
   (error) => {

--- a/src/services/SpotifyAPIManager/index.js
+++ b/src/services/SpotifyAPIManager/index.js
@@ -1,4 +1,20 @@
 import axios from 'axios';
+import Cookies from 'js-cookie';
+import { cookieNameForSpotifyAuth } from '../../constants';
+import SpotifyAuthManager from '../SpotifyAuthManager';
+
+const renewSpotifyToken = async () => {
+  const res = await SpotifyAuthManager.getToken();
+  Cookies.set(cookieNameForSpotifyAuth, res.data.access_token, {
+    expires: new Date(new Date().getTime() + 55 * 60 * 1000),
+  });
+  return res.data.access_token;
+};
+
+const token =
+  Cookies.get(cookieNameForSpotifyAuth) !== undefined
+    ? Cookies.get(cookieNameForSpotifyAuth)
+    : renewSpotifyToken();
 
 const API = axios.create({
   baseURL: 'https://api.spotify.com/v1/',
@@ -10,8 +26,7 @@ API.interceptors.request.use(
     headers: {
       ...headers,
       'Content-Type': 'application/json',
-      Authorization:
-        'Bearer BQCzCATqJ0MkZyTu8IVHWfSXFHbdqbRoVuN-DTv66wjlzD-Z-2EfANIuZqSkuckhltBfgsxG_8VesUm1tAY',
+      Authorization: `Bearer ${token}`,
     },
   }),
   (error) => {

--- a/src/services/SpotifyAuthManager/index.js
+++ b/src/services/SpotifyAuthManager/index.js
@@ -1,0 +1,27 @@
+import axios from 'axios';
+
+const API = axios.create({
+  baseURL: 'https://accounts.spotify.com/api/token',
+});
+
+API.interceptors.request.use(
+  ({ headers, ...config }) => ({
+    ...config,
+    headers: {
+      ...headers,
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization:
+        'Basic N2I3Mjc2YzljZTk0NGI5Yzg2NzExMGJkZjg2NmZmYjA6MzBhNmQwM2FiYTI4NGFjNWE1Mjg4NDRlZmIwYTI2NzU=',
+    },
+  }),
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+export default class SpotifyAuthManager {
+  static async getToken() {
+    const res = await API.post('', 'grant_type=client_credentials');
+    return res;
+  }
+}


### PR DESCRIPTION
**Related issues**

closes #33 

**Changes**

:heavy_plus_sign: add SpotifyAuthManager that retrieves a token

:heavy_plus_sign: add token checker in SpotifyAPIManager that checks generates spotify token, saves in cookies, expires 55 min (real spotify token expires 60 min)

:heavy_plus_sign: All requests to MixUp back API now carries user jwt token when possible

:heavy_minus_sign: useless imports in App.js

:heavy_minus_sign: deleted element 2

:hammer_and_wrench: playlist map without unique key issue

:hammer_and_wrench: changed/fixed element 2

:exclamation: Sometimes it does show an error message, need to F5

* * *
- [x] I ran this code locally